### PR TITLE
added literal-links flag to second transformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,6 @@ find "$folder_path" -type f -not -path "*/.git/*" -name "*.md" | while read -r f
     relative_path="${file#$folder_path/}"
     out_file="${out_path}/${relative_path%.md}.norg"
     mkdir -p "$(dirname "$out_file")"
-    cat "$file" | obsidian2neorg > "$out_file"
+    cat "$file" | obsidian2neorg --literal-links > "$out_file"
 done
 ```


### PR DESCRIPTION
In the README when explaining how to avoid lowercase-links the --literal-links flag was kept out of the command.